### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Winner gets a prize!
 In order to run this project you need:
 
 - [ ] [python3](https://docs.python-guide.org/starting/install3/osx/)
-- [ ] [github cli](https://github.com/cli/cli#installation)
 - [ ] [github account](https://github.com/)
 - [ ] [make for mac](https://formulae.brew.sh/formula/make) or [make for windows](https://gnuwin32.sourceforge.net/packages/make.htm)
 


### PR DESCRIPTION
* removed github cli from readme*

In prereq its written github cli but for setup when cloning ssh is used for which terminal is enough and we are not using github cli clone cmnd

are we using github cli, do we need github cli in prereq?